### PR TITLE
Close #10: Language support for different lengths

### DIFF
--- a/src/note.c
+++ b/src/note.c
@@ -5,9 +5,9 @@
 
 // --------
 
-void Note_init_at(Note* note, int pitch) {
+void Note_init_at(Note* note, int pitch, int length) {
 	note->pitch = pitch;
-	note->length = -2;
+	note->length = length;
 }
 
 float Note_get_frequency(const Note* note) {

--- a/src/note.h
+++ b/src/note.h
@@ -21,7 +21,7 @@ struct Note {
 
 // --------
 
-void Note_init_at(Note* note, int pitch);
+void Note_init_at(Note* note, int pitch, int length);
 
 float Note_get_frequency(const Note* note);
 float Note_get_absolute_length(const Note* note);

--- a/src/note_compiler.c
+++ b/src/note_compiler.c
@@ -60,6 +60,11 @@ static int finish_note(NoteCompiler* compiler, Note* note) {
 				half++;
 				break;
 
+			case 'b':
+				advance(compiler);
+				half--;
+				break;
+
 			default:
 				break;
 		}

--- a/src/note_compiler.c
+++ b/src/note_compiler.c
@@ -43,6 +43,7 @@ static int finish_note(NoteCompiler* compiler, Note* note) {
 	int half = 0;
 	int pitch = 0;
 	int length = -2;
+	bool note_finished = false;
 
 	char symbol = compiler->symbol;
 	int c = peek(compiler);
@@ -53,7 +54,7 @@ static int finish_note(NoteCompiler* compiler, Note* note) {
 
 	if(!compiler->finished) {
 
-		switch((char) c) {
+		switch(c) {
 
 			case '#':
 				advance(compiler);
@@ -66,6 +67,26 @@ static int finish_note(NoteCompiler* compiler, Note* note) {
 				break;
 
 			default:
+				break;
+		}
+	}
+
+	while(!note_finished && !compiler->finished && (c = peek(compiler)) >= 0) {
+
+		switch(c) {
+
+			case 'o':
+				advance(compiler);
+				length++;
+				continue;
+
+			case '^':
+				advance(compiler);
+				length--;
+				continue;
+
+			default:
+				note_finished = true;
 				break;
 		}
 	}

--- a/src/note_compiler.c
+++ b/src/note_compiler.c
@@ -39,8 +39,12 @@ static int peek(NoteCompiler* compiler) {
 
 static int finish_note(NoteCompiler* compiler, Note* note) {
 
-	char symbol = compiler->symbol;
+	int status = 0;
 	int half = 0;
+	int pitch = 0;
+	int length = -2;
+
+	char symbol = compiler->symbol;
 	int c = peek(compiler);
 
 	if(c < 0) {
@@ -61,7 +65,14 @@ static int finish_note(NoteCompiler* compiler, Note* note) {
 		}
 	}
 
-	return Note_musical_init_at(note, symbol, half);
+	status = Convert_musical_to_pitch(symbol, half, &pitch);
+	if(status != 0) {
+		return status;
+	}
+
+	Note_init_at(note, pitch, length);
+
+	return 0;
 }
 
 // --------

--- a/src/note_compiler.h
+++ b/src/note_compiler.h
@@ -17,8 +17,14 @@ typedef struct NoteCompiler NoteCompiler;
 
 // --------
 
+typedef enum NoteCompilerState {
+	NOTE_COMPILER_STATE_EXPECTING_NOTE = 0,
+	NUM_NOTE_COMPILER_STATES,
+} NoteCompilerState;
+
 struct NoteCompiler {
 	char* bar;
+	NoteCompilerState state;
 	size_t bar_length;
 	size_t position;
 	char symbol;

--- a/src/note_conversion.c
+++ b/src/note_conversion.c
@@ -13,7 +13,7 @@ int Note_musical_init_at(Note* note, char symbol, int half) {
 		return rv;
 	}
 
-	Note_init_at(note, pitch);
+	Note_init_at(note, pitch, -2);
 	return 0;
 }
 

--- a/src/note_conversion.c
+++ b/src/note_conversion.c
@@ -4,19 +4,6 @@
 
 // --------
 
-int Note_musical_init_at(Note* note, char symbol, int half) {
-
-	int pitch;
-
-	int rv = Convert_musical_to_pitch(symbol, half, &pitch);
-	if(rv != 0) {
-		return rv;
-	}
-
-	Note_init_at(note, pitch, -2);
-	return 0;
-}
-
 int Convert_musical_to_pitch(char symbol, int half, int* pitch) {
 
 	if(pitch == NULL) {

--- a/src/note_conversion.h
+++ b/src/note_conversion.h
@@ -6,8 +6,6 @@
 
 // --------
 
-int Note_musical_init_at(Note* note, char symbol, int half);
-
 int Convert_musical_to_pitch(char symbol, int half, int* pitch);
 
 // --------


### PR DESCRIPTION
This PR adds support to the `NoteCompiler` to parse length modifiers after the notes.

Closes #10 