### PR TITLE
Implement common "base class" for `Lexer` and `TrackLexer`

### DIFF
--- a/src/abstract_lexer.c
+++ b/src/abstract_lexer.c
@@ -108,3 +108,22 @@ int finalize_buffer(AbstractLexer* lexer) {
 	return append_char_to_buffer(lexer, (char) '\0');
 }
 
+int AbstractLexer_init_at(AbstractLexer* lexer, size_t initial_buffer_capacity) {
+
+	if(lexer == NULL) {
+		return ERROR_CODE_INVALID_ARGUMENT;
+	}
+
+	lexer->initial_buffer_capacity = initial_buffer_capacity;
+	lexer->line = 1;
+	lexer->col = 1;
+	lexer->symbol = '\0';
+	lexer->finished = false;
+	lexer->error = false;
+
+	update_lineinfo(lexer);
+	reset_buffer_info(lexer);
+
+	return 0;
+}
+

--- a/src/abstract_lexer.c
+++ b/src/abstract_lexer.c
@@ -1,0 +1,110 @@
+#include <stdlib.h>
+
+#include "abstract_lexer.h"
+#include "error_codes.h"
+
+// --------
+
+void update_lineinfo(AbstractLexer* lexer) {
+
+	lexer->saved_line = lexer->line;
+	lexer->saved_col = lexer->col;
+
+	return;
+}
+
+void reset_buffer_info(AbstractLexer* lexer) {
+
+	lexer->buffer = NULL;
+	lexer->buffer_capacity = 0;
+	lexer->buffer_length = 0;
+
+	return;
+}
+
+void free_buffer(AbstractLexer* lexer) {
+
+	free(lexer->buffer);
+	reset_buffer_info(lexer);
+
+	return;
+}
+
+int append_char_to_buffer(AbstractLexer* lexer, char c) {
+
+	if(lexer == NULL) {
+		return ERROR_CODE_INVALID_ARGUMENT;
+	}
+
+	if(lexer->buffer == NULL) {
+
+		if(lexer->buffer_capacity != 0 || lexer->buffer_length != 0) {
+			lexer->error = true;
+			lexer->finished = true;
+			return ERROR_CODE_INVALID_STATE;
+		}
+
+		lexer->buffer = malloc(lexer->initial_buffer_capacity);
+		if(lexer->buffer == NULL) {
+			lexer->error = true;
+			lexer->finished = true;
+			return ERROR_CODE_MALLOC_FAILURE;
+		}
+
+		lexer->buffer_capacity = lexer->initial_buffer_capacity;
+	}
+
+	else if(lexer->buffer_capacity == 0 || lexer->buffer_length == 0) {
+		lexer->error = true;
+		lexer->finished = true;
+		return ERROR_CODE_INVALID_STATE;
+	}
+
+	if(lexer->buffer_length >= lexer->buffer_capacity) {
+
+		size_t new_capacity = lexer->buffer_capacity * 2;
+		if(new_capacity <= lexer->buffer_capacity) {
+			lexer->error = true;
+			lexer->finished = true;
+			return ERROR_CODE_INTEGER_OVERFLOW;
+		}
+
+		char* new_buffer = realloc(lexer->buffer, new_capacity);
+		if(new_buffer == NULL) {
+			lexer->error = true;
+			lexer->finished = true;
+			return ERROR_CODE_MALLOC_FAILURE;
+		}
+
+		lexer->buffer = new_buffer;
+		lexer->buffer_capacity = new_capacity;
+	}
+
+	lexer->buffer[lexer->buffer_length] = c;
+
+	size_t new_length = lexer->buffer_length + 1;
+
+	if(new_length <= lexer->buffer_length) {
+		lexer->error = true;
+		lexer->finished = true;
+		return ERROR_CODE_INTEGER_OVERFLOW;
+	}
+
+	lexer->buffer_length = new_length;
+
+	return 0;
+}
+
+int append_current_symbol_to_buffer(AbstractLexer* lexer) {
+
+	if(lexer == NULL) {
+		return ERROR_CODE_INVALID_ARGUMENT;
+	}
+
+	return append_char_to_buffer(lexer, lexer->symbol);
+}
+
+int finalize_buffer(AbstractLexer* lexer) {
+	return append_char_to_buffer(lexer, (char) '\0');
+}
+

--- a/src/abstract_lexer.h
+++ b/src/abstract_lexer.h
@@ -3,6 +3,7 @@
 // --------
 
 #include <stdbool.h>
+#include <stddef.h>
 
 // --------
 
@@ -38,6 +39,8 @@ void free_buffer(AbstractLexer* lexer);
 int append_char_to_buffer(AbstractLexer* lexer, char c);
 int append_current_symbol_to_buffer(AbstractLexer* lexer);
 int finalize_buffer(AbstractLexer* lexer);
+
+int AbstractLexer_init_at(AbstractLexer* lexer, size_t initial_buffer_capacity);
 
 // --------
 #endif

--- a/src/abstract_lexer.h
+++ b/src/abstract_lexer.h
@@ -1,0 +1,44 @@
+#ifndef ABSTRACT_LEXER_H
+#define ABSTRACT_LEXER_H
+// --------
+
+#include <stdbool.h>
+
+// --------
+
+struct AbstractLexer;
+
+// --------
+
+typedef struct AbstractLexer AbstractLexer;
+
+// --------
+
+struct AbstractLexer {
+	char* buffer;
+	size_t buffer_capacity;
+	size_t buffer_length;
+	size_t initial_buffer_capacity;
+	unsigned int line;
+	unsigned int col;
+	unsigned int saved_line;
+	unsigned int saved_col;
+	char symbol;
+	bool finished;
+	bool error;
+};
+
+// --------
+
+void update_lineinfo(AbstractLexer* lexer);
+
+void reset_buffer_info(AbstractLexer* lexer);
+void free_buffer(AbstractLexer* lexer);
+
+int append_char_to_buffer(AbstractLexer* lexer, char c);
+int append_current_symbol_to_buffer(AbstractLexer* lexer);
+int finalize_buffer(AbstractLexer* lexer);
+
+// --------
+#endif
+

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -39,7 +39,11 @@ static int play_track_token(Player* player, Instrument* instrument, Token* track
 
 	TrackLexer lexer;
 	BarToken bar;
-	int status;
+
+	int status = 0;
+
+	memset(&lexer, 0, sizeof(Lexer));
+	memset(&bar, 0, sizeof(BarToken));
 
 	status = TrackLexer_init_at(&lexer, track);
 	if(status != 0) {
@@ -134,7 +138,7 @@ int Interpreter_interpret(Interpreter* interpreter, FILE* stream) {
 		return status;
 	}
 
-	while(!interpreter->finished && destroy_token(&token) && (status = Lexer_get_next_token(&lexer, &token)) == 0 && !lexer.finished) {
+	while(!interpreter->finished && destroy_token(&token) && (status = Lexer_get_next_token(&lexer, &token)) == 0 && !lexer.super.finished) {
 
 		if(token.type == TOKEN_COMMENT) {
 			continue;
@@ -187,8 +191,8 @@ int Interpreter_interpret(Interpreter* interpreter, FILE* stream) {
 		}
 	}
 
-	if(lexer.error) {
-		fprintf(stderr, "Error at %s:%u:%u\n", interpreter->filename, lexer.line, lexer.col);
+	if(lexer.super.error) {
+		fprintf(stderr, "Error at %s:%u:%u\n", interpreter->filename, lexer.super.line, lexer.super.col);
 		status = status != 0? status: ERROR_CODE_UNKNOWN_ERROR;
 	}
 

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -50,7 +50,7 @@ static int play_track_token(Player* player, Instrument* instrument, Token* track
 		return status;
 	}
 
-	while(status == 0 && destroy_bar_token(&bar) && !lexer.finished && (status = TrackLexer_get_next_bar(&lexer, &bar)) == 0) {
+	while(status == 0 && destroy_bar_token(&bar) && !lexer.super.finished && (status = TrackLexer_get_next_bar(&lexer, &bar)) == 0) {
 		status = play_bar_token(player, instrument, &bar);
 	}
 

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -1,5 +1,3 @@
-#include <stdlib.h>
-
 #include <string.h>
 
 #include "error_codes.h"
@@ -7,29 +5,22 @@
 
 // --------
 
-static int advance(Lexer* lexer);
-static int peek(Lexer* lexer);
+static int advance(AbstractLexer* lexer);
+static int peek(AbstractLexer* lexer);
 
-static void update_lineinfo(Lexer* lexer);
+static bool verify_keyword(AbstractLexer* lexer, char* keyword);
 
-static void reset_buffer_info(Lexer* lexer);
-static void free_buffer(Lexer* lexer);
-
-static int append_char_to_buffer(Lexer* lexer, char c);
-static int append_current_symbol_to_buffer(Lexer* lexer);
-static int finalize_buffer(Lexer* lexer);
-
-static bool verify_keyword(Lexer* lexer, char* keyword);
+static int Lexer_get_next_token_internal(AbstractLexer* lexer, Token* token);
 
 // --------
 
-static int advance(Lexer* lexer) {
+static int advance(AbstractLexer* lexer) {
 
 	if(lexer->finished | lexer->error) {
 		return EOF;
 	}
 
-	int c = getc(lexer->stream);
+	int c = getc(((Lexer*) lexer)->stream);
 	if(c == EOF) {
 		lexer->finished = true;
 		return c;
@@ -46,19 +37,19 @@ static int advance(Lexer* lexer) {
 	return c;
 }
 
-static int peek(Lexer* lexer) {
+static int peek(AbstractLexer* lexer) {
 
 	if(lexer->finished | lexer->error) {
 		return EOF;
 	}
 
-	int c = getc(lexer->stream);
+	int c = getc(((Lexer*) lexer)->stream);
 	if(c == EOF) {
 		lexer->finished = true;
 		return c;
 	}
 
-	int rv = ungetc(c, lexer->stream);
+	int rv = ungetc(c, ((Lexer*) lexer)->stream);
 	if(rv != c) {
 		lexer->finished = true;
 		lexer->error = true;
@@ -67,110 +58,7 @@ static int peek(Lexer* lexer) {
 	return rv;
 }
 
-static void update_lineinfo(Lexer* lexer) {
-
-	lexer->saved_line = lexer->line;
-	lexer->saved_col = lexer->col;
-
-	return;
-}
-
-static void reset_buffer_info(Lexer* lexer) {
-
-	lexer->buffer = NULL;
-	lexer->buffer_capacity = 0;
-	lexer->buffer_length = 0;
-
-	return;
-}
-
-static void free_buffer(Lexer* lexer) {
-
-	free(lexer->buffer);
-	reset_buffer_info(lexer);
-
-	return;
-}
-
-static int append_char_to_buffer(Lexer* lexer, char c) {
-
-	if(lexer == NULL) {
-		return ERROR_CODE_INVALID_ARGUMENT;
-	}
-
-	if(lexer->buffer == NULL) {
-
-		if(lexer->buffer_capacity != 0 || lexer->buffer_length != 0) {
-			lexer->error = true;
-			lexer->finished = true;
-			return ERROR_CODE_INVALID_STATE;
-		}
-
-		lexer->buffer = malloc(lexer->initial_buffer_capacity);
-		if(lexer->buffer == NULL) {
-			lexer->error = true;
-			lexer->finished = true;
-			return ERROR_CODE_MALLOC_FAILURE;
-		}
-
-		lexer->buffer_capacity = lexer->initial_buffer_capacity;
-	}
-
-	else if(lexer->buffer_capacity == 0 || lexer->buffer_length == 0) {
-		lexer->error = true;
-		lexer->finished = true;
-		return ERROR_CODE_INVALID_STATE;
-	}
-
-	if(lexer->buffer_length >= lexer->buffer_capacity) {
-
-		size_t new_capacity = lexer->buffer_capacity * 2;
-		if(new_capacity <= lexer->buffer_capacity) {
-			lexer->error = true;
-			lexer->finished = true;
-			return ERROR_CODE_INTEGER_OVERFLOW;
-		}
-
-		char* new_buffer = realloc(lexer->buffer, new_capacity);
-		if(new_buffer == NULL) {
-			lexer->error = true;
-			lexer->finished = true;
-			return ERROR_CODE_MALLOC_FAILURE;
-		}
-
-		lexer->buffer = new_buffer;
-		lexer->buffer_capacity = new_capacity;
-	}
-
-	lexer->buffer[lexer->buffer_length] = c;
-
-	size_t new_length = lexer->buffer_length + 1;
-
-	if(new_length <= lexer->buffer_length) {
-		lexer->error = true;
-		lexer->finished = true;
-		return ERROR_CODE_INTEGER_OVERFLOW;
-	}
-
-	lexer->buffer_length = new_length;
-
-	return 0;
-}
-
-static int append_current_symbol_to_buffer(Lexer* lexer) {
-
-	if(lexer == NULL) {
-		return ERROR_CODE_INVALID_ARGUMENT;
-	}
-
-	return append_char_to_buffer(lexer, lexer->symbol);
-}
-
-static int finalize_buffer(Lexer* lexer) {
-	return append_char_to_buffer(lexer, (char) '\0');
-}
-
-static bool verify_keyword(Lexer* lexer, char* keyword) {
+static bool verify_keyword(AbstractLexer* lexer, char* keyword) {
 
 	size_t index = 0;
 	size_t length = strlen(keyword);
@@ -197,47 +85,7 @@ static bool verify_keyword(Lexer* lexer, char* keyword) {
 	}
 }
 
-// --------
-
-int Lexer_init_at(Lexer* lexer, FILE* stream) {
-
-	if(lexer == NULL) {
-		return ERROR_CODE_INVALID_ARGUMENT;
-	}
-
-	if(stream == NULL) {
-		lexer->error = true;
-		lexer->finished = true;
-		return ERROR_CODE_INVALID_ARGUMENT;
-	}
-
-	lexer->initial_buffer_capacity = 256;
-	lexer->symbol = '\0';
-	lexer->line = 1;
-	lexer->col = 1;
-	lexer->finished = false;
-	lexer->error = false;
-	lexer->state = LEXER_STATE_EXPECTING_NEW_TOKEN;
-	lexer->stream = stream;
-
-	update_lineinfo(lexer);
-	reset_buffer_info(lexer);
-
-	return 0;
-}
-
-void Lexer_destroy_at(Lexer* lexer) {
-
-	if(lexer == NULL) {
-		return;
-	}
-
-	free_buffer(lexer);
-
-	return;
-}
-
-int Lexer_get_next_token(Lexer* lexer, Token* token) {
+static int Lexer_get_next_token_internal(AbstractLexer* lexer, Token* token) {
 
 	if(lexer == NULL || lexer->finished || lexer->error) {
 		return ERROR_CODE_INVALID_ARGUMENT;
@@ -257,7 +105,7 @@ int Lexer_get_next_token(Lexer* lexer, Token* token) {
 
 		int status = 0;
 
-		switch(lexer->state) {
+		switch(((Lexer*) lexer)->state) {
 
 			case LEXER_STATE_EXPECTING_NEW_TOKEN:
 
@@ -293,7 +141,7 @@ int Lexer_get_next_token(Lexer* lexer, Token* token) {
 							return status;
 						}
 
-						lexer->state = LEXER_STATE_EXPECTING_TRACK;
+						((Lexer*) lexer)->state = LEXER_STATE_EXPECTING_TRACK;
 
 						continue;
 
@@ -303,7 +151,7 @@ int Lexer_get_next_token(Lexer* lexer, Token* token) {
 							return ERROR_CODE_UNEXPECTED_CHARACTER;
 						}
 
-						lexer->state = LEXER_STATE_EXPECTING_COMMENT;
+						((Lexer*) lexer)->state = LEXER_STATE_EXPECTING_COMMENT;
 
 						continue;
 
@@ -354,7 +202,7 @@ int Lexer_get_next_token(Lexer* lexer, Token* token) {
 						Token_set_content(token, lexer->buffer, lexer->buffer_length);
 						reset_buffer_info(lexer);
 
-						lexer->state = LEXER_STATE_EXPECTING_NEW_TOKEN;
+						((Lexer*) lexer)->state = LEXER_STATE_EXPECTING_NEW_TOKEN;
 
 						return 0;
 
@@ -378,7 +226,7 @@ int Lexer_get_next_token(Lexer* lexer, Token* token) {
 						Token_set_content(token, lexer->buffer, lexer->buffer_length);
 						reset_buffer_info(lexer);
 
-						lexer->state = LEXER_STATE_EXPECTING_NEW_TOKEN;
+						((Lexer*) lexer)->state = LEXER_STATE_EXPECTING_NEW_TOKEN;
 
 						return 0;
 
@@ -398,5 +246,41 @@ int Lexer_get_next_token(Lexer* lexer, Token* token) {
 
 	lexer->finished = true;
 	return 0;
+}
+
+// --------
+
+int Lexer_init_at(Lexer* lexer, FILE* stream) {
+
+	int status = AbstractLexer_init_at((AbstractLexer*) lexer, 256);
+	if(status != 0) {
+		return status;
+	}
+
+	if(stream == NULL) {
+		((AbstractLexer*) lexer)->error = true;
+		((AbstractLexer*) lexer)->finished = true;
+		return ERROR_CODE_INVALID_ARGUMENT;
+	}
+
+	lexer->state = LEXER_STATE_EXPECTING_NEW_TOKEN;
+	lexer->stream = stream;
+
+	return 0;
+}
+
+void Lexer_destroy_at(Lexer* lexer) {
+
+	if(lexer == NULL) {
+		return;
+	}
+
+	free_buffer((AbstractLexer*) lexer);
+
+	return;
+}
+
+int Lexer_get_next_token(Lexer* lexer, Token* token) {
+	return Lexer_get_next_token_internal((AbstractLexer*) lexer, token);
 }
 

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -1,3 +1,5 @@
+#include <stdlib.h>
+
 #include <string.h>
 
 #include "error_codes.h"

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -3,8 +3,8 @@
 // --------
 
 #include <stdio.h>
-#include <stdbool.h>
 
+#include "abstract_lexer.h"
 #include "token.h"
 
 // --------
@@ -25,17 +25,7 @@ typedef enum LexerState {
 } LexerState;
 
 struct Lexer {
-	char* buffer;
-	size_t buffer_capacity;
-	size_t buffer_length;
-	size_t initial_buffer_capacity;
-	unsigned int line;
-	unsigned int col;
-	unsigned int saved_line;
-	unsigned int saved_col;
-	char symbol;
-	bool finished;
-	bool error;
+	AbstractLexer super;
 	LexerState state;
 	FILE* stream;
 };

--- a/src/track_lexer.h
+++ b/src/track_lexer.h
@@ -2,8 +2,7 @@
 #define TRACK_LEXER_H
 // --------
 
-#include <stdbool.h>
-
+#include "abstract_lexer.h"
 #include "bar_token.h"
 #include "token.h"
 
@@ -25,17 +24,7 @@ typedef enum TrackLexerState {
 } TrackLexerState;
 
 struct TrackLexer {
-	char* buffer;
-	size_t buffer_capacity;
-	size_t buffer_length;
-	size_t initial_buffer_capacity;
-	unsigned int line;
-	unsigned int col;
-	unsigned int saved_line;
-	unsigned int saved_col;
-	char symbol;
-	bool finished;
-	bool error;
+	AbstractLexer super;
 	TrackLexerState state;
 	Token* track;
 	size_t track_position;


### PR DESCRIPTION
This PR implements a form of polymorphism/inheritance to have the `Lexer` and `TrackLexer` "derive" from a common base class, massively reducing code duplication.

As noted [here](https://github.com/zzril/aula/pull/47#issuecomment-2477095836), we probably want to switch to C++ in the long-term, with native support for this stuff.