### PR TITLE
Add Token printing functions

### DIFF
--- a/src/bar_token.c
+++ b/src/bar_token.c
@@ -3,6 +3,7 @@
 #include <string.h>
 
 #include "bar_token.h"
+#include "error_codes.h"
 
 // --------
 
@@ -32,5 +33,20 @@ void BarToken_destroy_at(BarToken* token) {
 	memset(token, 0, sizeof(BarToken));
 
 	return;
+}
+
+int BarToken_print(BarToken* token, FILE* stream) {
+
+	if(token == NULL || token->content == NULL || stream == NULL) {
+		return ERROR_CODE_INVALID_ARGUMENT;
+	}
+
+	if(token->content_length == 0) {
+		return 0;
+	}
+
+	fputs(token->content, stream);
+
+	return 0;
 }
 

--- a/src/bar_token.h
+++ b/src/bar_token.h
@@ -3,6 +3,7 @@
 // --------
 
 #include <stddef.h>
+#include <stdio.h>
 
 // --------
 
@@ -28,6 +29,8 @@ void BarToken_init_at(BarToken* token, unsigned int line, unsigned int col);
 void BarToken_set_content(BarToken* token, char* content, size_t content_length);
 
 void BarToken_destroy_at(BarToken* token);
+
+int BarToken_print(BarToken* token, FILE* stream);
 
 // --------
 #endif

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -202,41 +202,17 @@ int Interpreter_interpret(Interpreter* interpreter, FILE* stream) {
 
 			case INTERPRETER_ERROR_STATE_UNEXPECTED_TOKEN:
 
-				fprintf(stderr, "%s:%u:%u: Unexpected token\n", interpreter->filename, token.line, token.col);
-
-				switch(token.type) {
-
-					case TOKEN_TRACK:
-					case TOKEN_COMMENT:
-
-						if(token.content.buffer != NULL) {
-							fputs((char*) (token.content.buffer), stderr);
-						}
-						break;
-
-					default:
-						break;
-				}
+				fprintf(stderr, "%s:%u:%u: Unexpected token: ", interpreter->filename, token.line, token.col);
+				Token_print(&token, stderr);
+				fputs("\n", stderr);
 
 				break;
 
 			case INTERPRETER_ERROR_STATE_INTERNAL_ERROR:
 
-				switch(token.type) {
-
-					case TOKEN_TRACK:
-					case TOKEN_COMMENT:
-
-						if(token.content.buffer != NULL) {
-							fprintf(stderr, "Internal interpreter error while processing %s:%u:%u: %s\n", interpreter->filename, token.line, token.col, (char*) (token.content.buffer));
-							break;
-						}
-
-					default:
-
-						fprintf(stderr, "Internal interpreter error while processing %s:%u:%u\n", interpreter->filename, token.line, token.col);
-
-				}
+				fprintf(stderr, "%s:%u:%u: Internal interpreter error while processing: ", interpreter->filename, token.line, token.col);
+				Token_print(&token, stderr);
+				fputs("\n", stderr);
 
 				break;
 

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -11,7 +11,7 @@
 static int advance(AbstractLexer* lexer);
 static int peek(AbstractLexer* lexer);
 
-static bool verify_keyword(AbstractLexer* lexer, char* keyword);
+static bool verify_keyword(AbstractLexer* lexer, const char* keyword);
 
 static int Lexer_get_next_token_internal(AbstractLexer* lexer, Token* token);
 
@@ -61,7 +61,7 @@ static int peek(AbstractLexer* lexer) {
 	return rv;
 }
 
-static bool verify_keyword(AbstractLexer* lexer, char* keyword) {
+static bool verify_keyword(AbstractLexer* lexer, const char* keyword) {
 
 	size_t index = 0;
 	size_t length = strlen(keyword);
@@ -146,8 +146,8 @@ static int Lexer_get_next_token_internal(AbstractLexer* lexer, Token* token) {
 
 					case 'b':
 
-						if(verify_keyword(lexer, "bpm:") == false) {
-							return ERROR_CODE_UNEXPECTED_FOLLOW_UP_CHARACTER;
+						if(verify_keyword(lexer, TOKEN_KEYWORDS[TOKEN_KEYWORD_BPM]) == false) {
+							return ERROR_CODE_UNEXPECTED_CHARACTER;
 						}
 
 						Token_init_at(token, TOKEN_KEYWORD_BPM, lexer->saved_line, lexer->saved_col);
@@ -156,8 +156,8 @@ static int Lexer_get_next_token_internal(AbstractLexer* lexer, Token* token) {
 
 					case 't':
 
-						if(verify_keyword(lexer, "track:") == false) {
-							return ERROR_CODE_UNEXPECTED_FOLLOW_UP_CHARACTER;
+						if(verify_keyword(lexer, TOKEN_KEYWORDS[TOKEN_KEYWORD_TRACK]) == false) {
+							return ERROR_CODE_UNEXPECTED_CHARACTER;
 						}
 
 						Token_init_at(token, TOKEN_KEYWORD_TRACK, lexer->saved_line, lexer->saved_col);

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -181,8 +181,13 @@ static int Lexer_get_next_token_internal(AbstractLexer* lexer, Token* token) {
 
 					case '/':
 
-						if(advance(lexer) != (int) '/') {
-							return ERROR_CODE_UNEXPECTED_CHARACTER;
+						if(peek(lexer) != (int) '/') {
+							return ERROR_CODE_UNEXPECTED_FOLLOW_UP_CHARACTER;
+						}
+
+						status = append_current_symbol_to_buffer(lexer);
+						if(status != 0) {
+							return status;
 						}
 
 						((Lexer*) lexer)->state = LEXER_STATE_EXPECTING_COMMENT;

--- a/src/token.c
+++ b/src/token.c
@@ -77,7 +77,17 @@ int Token_print(Token* token, FILE* stream) {
 
 		case TOKEN_TRACK:
 		case TOKEN_COMMENT:
+
+			if(token->content.buffer == NULL) {
+				return ERROR_CODE_INVALID_STATE;
+			}
+
+			if(token->content_length == 0) {
+				return 0;
+			}
+
 			fputs(token->content.buffer, stream);
+
 			return 0;
 
 		case TOKEN_LITERAL_INTEGER:

--- a/src/token.c
+++ b/src/token.c
@@ -7,7 +7,7 @@
 
 // --------
 
-static const char* TOKEN_KEYWORDS[NUM_TOKEN_KEYWORD_TYPES] = {
+const char* TOKEN_KEYWORDS[NUM_TOKEN_KEYWORD_TYPES] = {
 	[TOKEN_INVALID] = "<invalid token>",
 	[TOKEN_KEYWORD_BPM] = "bpm:",
 	[TOKEN_KEYWORD_TRACK] = "track:",

--- a/src/token.c
+++ b/src/token.c
@@ -62,10 +62,10 @@ void Token_destroy_at(Token* token) {
 	return;
 }
 
-void Token_print(Token* token, FILE* stream) {
+int Token_print(Token* token, FILE* stream) {
 
 	if(token == NULL || stream == NULL) {
-		return;
+		return ERROR_CODE_INVALID_ARGUMENT;
 	}
 
 	switch(token->type) {
@@ -73,20 +73,20 @@ void Token_print(Token* token, FILE* stream) {
 		case TOKEN_KEYWORD_BPM:
 		case TOKEN_KEYWORD_TRACK:
 			fputs(TOKEN_KEYWORDS[token->type], stream);
-			return;
+			return 0;
 
 		case TOKEN_TRACK:
 		case TOKEN_COMMENT:
 			fputs(token->content.buffer, stream);
-			return;
+			return 0;
 
 		case TOKEN_LITERAL_INTEGER:
 			fprintf(stream, "%d", token->content.integer);
-			return;
+			return 0;
 
 		default:
 			fputs(TOKEN_KEYWORDS[TOKEN_INVALID], stream);
-			return;
+			return 0;
 	}
 }
 

--- a/src/token.c
+++ b/src/token.c
@@ -7,6 +7,14 @@
 
 // --------
 
+static const char* TOKEN_KEYWORDS[NUM_TOKEN_KEYWORD_TYPES] = {
+	[TOKEN_INVALID] = "<invalid token>",
+	[TOKEN_KEYWORD_BPM] = "bpm:",
+	[TOKEN_KEYWORD_TRACK] = "track:",
+};
+
+// --------
+
 void Token_init_at(Token* token, TokenType type, unsigned int line, unsigned int col) {
 
 	token->type = type;
@@ -52,5 +60,33 @@ void Token_destroy_at(Token* token) {
 	memset(token, 0, sizeof(Token));
 
 	return;
+}
+
+void Token_print(Token* token, FILE* stream) {
+
+	if(token == NULL || stream == NULL) {
+		return;
+	}
+
+	switch(token->type) {
+
+		case TOKEN_KEYWORD_BPM:
+		case TOKEN_KEYWORD_TRACK:
+			fputs(TOKEN_KEYWORDS[token->type], stream);
+			return;
+
+		case TOKEN_TRACK:
+		case TOKEN_COMMENT:
+			fputs(token->content.buffer, stream);
+			return;
+
+		case TOKEN_LITERAL_INTEGER:
+			fprintf(stream, "%d", token->content.integer);
+			return;
+
+		default:
+			fputs(TOKEN_KEYWORDS[TOKEN_INVALID], stream);
+			return;
+	}
 }
 

--- a/src/token.h
+++ b/src/token.h
@@ -3,6 +3,7 @@
 // --------
 
 #include <stddef.h>
+#include <stdio.h>
 
 // --------
 
@@ -18,6 +19,7 @@ typedef enum TokenType {
 	TOKEN_INVALID = 0,
 	TOKEN_KEYWORD_BPM,
 	TOKEN_KEYWORD_TRACK,
+	NUM_TOKEN_KEYWORD_TYPES,
 	TOKEN_LITERAL_INTEGER,
 	TOKEN_TRACK,
 	TOKEN_COMMENT,
@@ -44,6 +46,8 @@ void Token_init_at(Token* token, TokenType type, unsigned int line, unsigned int
 int Token_set_content_buffer(Token* token, char* buffer, size_t length);
 
 void Token_destroy_at(Token* token);
+
+void Token_print(Token* token, FILE* stream);
 
 // --------
 #endif

--- a/src/token.h
+++ b/src/token.h
@@ -41,6 +41,10 @@ struct Token {
 
 // --------
 
+extern const char* TOKEN_KEYWORDS[NUM_TOKEN_KEYWORD_TYPES];
+
+// --------
+
 void Token_init_at(Token* token, TokenType type, unsigned int line, unsigned int col);
 
 int Token_set_content_buffer(Token* token, char* buffer, size_t length);

--- a/src/token.h
+++ b/src/token.h
@@ -51,7 +51,7 @@ int Token_set_content_buffer(Token* token, char* buffer, size_t length);
 
 void Token_destroy_at(Token* token);
 
-void Token_print(Token* token, FILE* stream);
+int Token_print(Token* token, FILE* stream);
 
 // --------
 #endif


### PR DESCRIPTION
As noted [here](https://github.com/zzril/aula/pull/44#issuecomment-2480812874), the code for printing out tokens as used by the `Interpreter` really belongs into the `Token` module.  
This PR accomplishes that.