### PR TITLE
Provide reallocarray implementation for Android API <= 29

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2024 Severin Paul Höfer
+Copyright (c) 2025 Severin Paul Höfer
+Copyright (c) 2008 Otto Moerbeek <otto@drijf.net> - `src/reallocarray.c`
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/instrument.c
+++ b/src/instrument.c
@@ -7,6 +7,7 @@
 #include "config.h"
 #include "error_codes.h"
 #include "instrument.h"
+#include "reallocarray.h"
 #include "wave.h"
 
 // --------

--- a/src/mixer.c
+++ b/src/mixer.c
@@ -6,6 +6,7 @@
 #include "config.h"
 #include "error_codes.h"
 #include "mixer.h"
+#include "reallocarray.h"
 #include "wave.h"
 
 // --------

--- a/src/reallocarray.c
+++ b/src/reallocarray.c
@@ -1,0 +1,61 @@
+/*	$OpenBSD: reallocarray.c,v 1.3 2015/09/13 08:31:47 guenther Exp $	*/
+/*
+ * Copyright (c) 2008 Otto Moerbeek <otto@drijf.net>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+// --------
+
+/*
+ * Modified version intended only for compilation inside Termux
+ * (which uses Android API 24, which doesn't have reallocarray).
+ */
+
+// --------
+
+#if defined __ANDROID_API__ && __ANDROID_API__ <= 29
+
+// --------
+
+#include <stdlib.h>
+
+#include <errno.h>
+
+#include "reallocarray.h"
+
+// --------
+
+/*
+ * This is sqrt(SIZE_MAX+1), as s1*s2 <= SIZE_MAX
+ * if both s1 < MUL_NO_OVERFLOW and s2 < MUL_NO_OVERFLOW
+ */
+#define MUL_NO_OVERFLOW	((size_t)1 << (sizeof(size_t) * 4))
+
+// --------
+
+void *
+reallocarray(void *optr, size_t nmemb, size_t size)
+{
+	if ((nmemb >= MUL_NO_OVERFLOW || size >= MUL_NO_OVERFLOW) &&
+	    nmemb > 0 && SIZE_MAX / nmemb < size) {
+		errno = ENOMEM;
+		return NULL;
+	}
+	return realloc(optr, size * nmemb);
+}
+
+#endif
+
+// --------
+

--- a/src/reallocarray.c
+++ b/src/reallocarray.c
@@ -24,25 +24,19 @@
 
 // --------
 
-#if defined __ANDROID_API__ && __ANDROID_API__ <= 29
-
-// --------
-
-#include <stdlib.h>
-
-#include <errno.h>
-
 #include "reallocarray.h"
 
 // --------
+
+#if defined __ANDROID_API__ && __ANDROID_API__ <= 29
+
+#include <errno.h>
 
 /*
  * This is sqrt(SIZE_MAX+1), as s1*s2 <= SIZE_MAX
  * if both s1 < MUL_NO_OVERFLOW and s2 < MUL_NO_OVERFLOW
  */
 #define MUL_NO_OVERFLOW	((size_t)1 << (sizeof(size_t) * 4))
-
-// --------
 
 void *
 reallocarray(void *optr, size_t nmemb, size_t size)
@@ -56,6 +50,4 @@ reallocarray(void *optr, size_t nmemb, size_t size)
 }
 
 #endif
-
-// --------
 

--- a/src/reallocarray.h
+++ b/src/reallocarray.h
@@ -2,17 +2,13 @@
 #define REALLOCARRAY_H
 // --------
 
+#include <stdlib.h>
+
+// --------
+
 #if defined __ANDROID_API__ && __ANDROID_API__ <= 29
 
-// --------
-
-#include <stddef.h>
-
-// --------
-
 void* reallocarray(void* ptr, size_t nmemb, size_t size);
-
-// --------
 
 #endif
 

--- a/src/reallocarray.h
+++ b/src/reallocarray.h
@@ -1,0 +1,21 @@
+#ifndef REALLOCARRAY_H
+#define REALLOCARRAY_H
+// --------
+
+#if defined __ANDROID_API__ && __ANDROID_API__ <= 29
+
+// --------
+
+#include <stddef.h>
+
+// --------
+
+void *reallocarray(void *ptr, size_t nmemb, size_t size);
+
+// --------
+
+#endif
+
+// --------
+#endif
+

--- a/src/reallocarray.h
+++ b/src/reallocarray.h
@@ -10,7 +10,7 @@
 
 // --------
 
-void *reallocarray(void *ptr, size_t nmemb, size_t size);
+void* reallocarray(void* ptr, size_t nmemb, size_t size);
 
 // --------
 


### PR DESCRIPTION
This adds OpenBSD's `reallocarray` implementation when compiling for Android, targeting API versions <= 29.

Closes #52 